### PR TITLE
Convert config value for use_mod_kerb to bool

### DIFF
--- a/tcms_api/__init__.py
+++ b/tcms_api/__init__.py
@@ -60,6 +60,7 @@ Connect to backend::
 """
 import os
 from configparser import ConfigParser
+from distutils.util import strtobool
 
 from .xmlrpc import TCMSXmlrpc, TCMSKerbXmlrpc
 
@@ -94,7 +95,7 @@ class TCMS:  # pylint: disable=too-few-public-methods
             raise Exception("No url found in %s" % self._path)
         self._parsed = True
 
-        if config['tcms'].get('use_mod_kerb', False):
+        if strtobool(config['tcms'].get('use_mod_kerb', 'False')):
             # use Kerberos
             TCMS._connection = TCMSKerbXmlrpc(config['tcms']['url']).server
 


### PR DESCRIPTION
when use_mod_kerb key was specified config returned its value
as a string which evaluated to True and caused the if condition to
actually configure the connection to use Kerberos although we
didn't want that. This caused failures on Windows where the
kerberos library isn't available.