### PR TITLE
Update xmlrpc.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # coding: utf-8
 # pylint: disable=missing-docstring
 from setuptools import setup
+import sys
 
 
 with open("README.rst") as readme:

--- a/tcms_api/xmlrpc.py
+++ b/tcms_api/xmlrpc.py
@@ -14,12 +14,12 @@ History:
 from http.client import HTTPSConnection
 from http.cookiejar import CookieJar
 from xmlrpc.client import SafeTransport, Transport, ServerProxy
+import os
 
-try:
-    import kerberos
-except ImportError:
+if sys.platform.startswith("win") 
     import winkerberos as kerberos
-
+else
+    import kerberos    
 
 VERBOSE = 0
 

--- a/tcms_api/xmlrpc.py
+++ b/tcms_api/xmlrpc.py
@@ -16,9 +16,9 @@ from http.cookiejar import CookieJar
 from xmlrpc.client import SafeTransport, Transport, ServerProxy
 import sys
 
-if sys.platform.startswith("win") 
+if sys.platform.startswith("win"):
     import winkerberos as kerberos
-else
+else:
     import kerberos    
 
 VERBOSE = 0

--- a/tcms_api/xmlrpc.py
+++ b/tcms_api/xmlrpc.py
@@ -15,7 +15,10 @@ from http.client import HTTPSConnection
 from http.cookiejar import CookieJar
 from xmlrpc.client import SafeTransport, Transport, ServerProxy
 
-import kerberos
+try:
+    import kerberos
+except ImportError:
+    import winkerberos as kerberos
 
 
 VERBOSE = 0

--- a/tcms_api/xmlrpc.py
+++ b/tcms_api/xmlrpc.py
@@ -19,7 +19,7 @@ import sys
 if sys.platform.startswith("win"):
     import winkerberos as kerberos
 else:
-    import kerberos    
+    import kerberos
 
 VERBOSE = 0
 

--- a/tcms_api/xmlrpc.py
+++ b/tcms_api/xmlrpc.py
@@ -14,7 +14,7 @@ History:
 from http.client import HTTPSConnection
 from http.cookiejar import CookieJar
 from xmlrpc.client import SafeTransport, Transport, ServerProxy
-import os
+import sys
 
 if sys.platform.startswith("win") 
     import winkerberos as kerberos


### PR DESCRIPTION
To support using winkerberos instead of kerberos module when running the tcms-api on Microsoft Windows platform.

Background: 
The kerberos module does not support Microsoft Windows platform. We need to replace it with the winkerberos.
While there is a workaround in the pip installation, but the code itself does not detect the platform and use the correct module.
Adding the above would try to import kerberos first, and if failed, will use winkerberos.