### PR TITLE
Fix super() call in CookieTransport for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 sudo: required
 language: python
 python:
@@ -9,6 +9,14 @@ env:
   - MAKE=pylint
   - MAKE=test-codecov
   - MAKE=build
+
+matrix:
+  include:
+    - python: 3.7
+      env: MAKE=test-codecov
+
+    - python: 3.8
+      env: MAKE=test-codecov
 
 install:
   - pip install -r devel.txt

--- a/tcms_api/xmlrpc.py
+++ b/tcms_api/xmlrpc.py
@@ -21,8 +21,8 @@ class CookieTransport(Transport):
     scheme = 'http'
     user_agent = 'tcms-api/%s' % __version__
 
-    def __init__(self, use_datetime=False, use_builtin_types=False):
-        super().__init__(use_datetime, use_builtin_types)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._cookies = []
 
     def send_headers(self, connection, headers):


### PR DESCRIPTION
This commit fixes "TypeError: \_\_init\_\_() got an unexpected keyword
argument 'headers'" when importing the module using Python 3.8.

Python 3.8 added the 'headers' argument to classes in xmlrpc.client. The
problem was caused by creating a KerbTransport() instance. Its MRO is
(\_\_main\_\_.KerbTransport, \_\_main\_\_.SafeCookieTransport,
xmlrpc.client.SafeTransport, \_\_main\_\_.CookieTransport,
xmlrpc.client.Transport, object), and therefore
xmlrpc.client.SafeTransport passed headers=() to CookieTransport, which
didn't expect that.