### PR TITLE
Replace deprecated urllib.parse functions for usage with newer Python

### DIFF
--- a/tcms_api/xmlrpc.py
+++ b/tcms_api/xmlrpc.py
@@ -91,9 +91,8 @@ def get_hostname(url):
     generate the service principal name for Kiwi TCMS and
     the respective Authorize header!
     """
-    _type, uri = urllib.parse.splittype(url)
-    hostname, _path = urllib.parse.splithost(uri)
-    return hostname
+    result = urllib.parse.urlparse(url)
+    return result.netloc
 
 
 class TCMSXmlrpc:


### PR DESCRIPTION
DeprecationWarning: urllib.parse.splittype() is deprecated as of 3.8, use urllib.parse.urlparse() instead
DeprecationWarning: urllib.parse.splithost() is deprecated as of 3.8, use urllib.parse.urlparse() instead