### PR TITLE
Fetch Kiwi TCMS' CA certificate and install it locally during testing

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,6 +57,25 @@ jobs:
         WEB_ADDR=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' web_kiwitcms_org`
         sudo sh -c "echo '$WEB_ADDR    web.kiwitcms.org' >> /etc/hosts"
 
+    - name: Install ca.crt from Kiwi TCMS
+      run: |
+        # regenerate new certificate, valid for the hostname used during testing
+        docker exec -i web_kiwitcms_org /usr/bin/sscg -v -f \
+                                            --hostname "web.kiwitcms.org"  \
+                                            --country BG --locality Sofia \
+                                            --organization "Kiwi TCMS" \
+                                            --organizational-unit "Quality Engineering" \
+                                            --ca-file       /Kiwi/static/ca.crt     \
+                                            --cert-file     /Kiwi/ssl/localhost.crt \
+                                            --cert-key-file /Kiwi/ssl/localhost.key
+
+        # restart web service so that it uses the new certificate
+        docker-compose -f tests/krb5/docker-compose.yml restart web_kiwitcms_org
+
+        sudo mkdir -p /usr/local/share/ca-certificates/
+        sudo curl --insecure https://web.kiwitcms.org:8443/static/ca.crt --output /usr/local/share/ca-certificates/Kiwi_TCMS_CA.crt
+        sudo update-ca-certificates --fresh --verbose
+
     - name: Install & configure Kerberos client
       if: matrix.os == 'ubuntu-latest' && matrix.gssapi == 'with'
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,6 +76,12 @@ jobs:
         sudo curl --insecure https://web.kiwitcms.org:8443/static/ca.crt --output /usr/local/share/ca-certificates/Kiwi_TCMS_CA.crt
         sudo update-ca-certificates --fresh --verbose
 
+        # this isn't actually needed, b/c the CA is in the system trust store
+        # export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+        # export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+        # export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+        # export SSL_CERT_DIR=/etc/ssl/certs/
+
     - name: Install & configure Kerberos client
       if: matrix.os == 'ubuntu-latest' && matrix.gssapi == 'with'
       run: |

--- a/tests/krb5/integration_test.py
+++ b/tests/krb5/integration_test.py
@@ -1,38 +1,14 @@
 #!/usr/bin/env python
 
 #
-# Copyright (c) 2020-2021 Kiwi TCMS project. All rights reserved.
+# Copyright (c) 2020-2024 Kiwi TCMS project. All rights reserved.
 # Author: Alexander Todorov <info@kiwitcms.org>
 #
 
-import ssl
 import unittest
-from unittest.mock import patch
 
 from datetime import datetime
-
-import requests
 from tcms_api import TCMS
-
-
-try:
-    _create_unverified_https_context = ssl._create_unverified_context
-except AttributeError:
-    # Legacy Python that doesn't verify HTTPS certificates by default
-    pass
-else:
-    # Handle target environment that doesn't support HTTPS verification
-    ssl._create_default_https_context = _create_unverified_https_context
-
-
-class DoNotVerifySSLSession(requests.sessions.Session):
-    def __init__(self):
-        super().__init__()
-        self.verify = False
-
-    def get(self, url, **kwargs):
-        kwargs.setdefault("verify", False)
-        return super().get(url, **kwargs)
 
 
 class IntegrationTestCase(unittest.TestCase):
@@ -41,31 +17,25 @@ class IntegrationTestCase(unittest.TestCase):
         cls.rpc = TCMS().exec
 
     def test_readonly_filtering_works(self):
-        with patch("requests.sessions.Session") as session:
-            session.return_value = DoNotVerifySSLSession()
-
-            results = self.rpc.Product.filter({})
-            self.assertGreater(len(results), 0)
+        results = self.rpc.Product.filter({})
+        self.assertGreater(len(results), 0)
 
     def test_create_objects_works(self):
-        with patch("requests.sessions.Session") as session:
-            session.return_value = DoNotVerifySSLSession()
+        now = datetime.now().isoformat()
 
-            now = datetime.now().isoformat()
+        result = self.rpc.Classification.filter(
+            {
+                "name": "test-products",
+            }
+        )[0]
+        self.assertEqual(result["name"], "test-products")
+        classification_id = result["id"]
 
-            result = self.rpc.Classification.filter(
-                {
-                    "name": "test-products",
-                }
-            )[0]
-            self.assertEqual(result["name"], "test-products")
-            classification_id = result["id"]
-
-            product_name = "tcms-api-%s" % now
-            result = self.rpc.Product.create(
-                {"name": product_name, "classification": classification_id}
-            )
-            self.assertEqual(result["name"], product_name)
+        product_name = "tcms-api-%s" % now
+        result = self.rpc.Product.create(
+            {"name": product_name, "classification": classification_id}
+        )
+        self.assertEqual(result["name"], product_name)
 
 
 if __name__ == "__main__":

--- a/tests/krb5/python_credentials_test.py
+++ b/tests/krb5/python_credentials_test.py
@@ -5,32 +5,9 @@
 # Author: Alexander Todorov <info@kiwitcms.org>
 #
 
-import ssl
 import unittest
-from unittest.mock import patch
 
-import requests
 from tcms_api import TCMS
-
-
-try:
-    _create_unverified_https_context = ssl._create_unverified_context
-except AttributeError:
-    # Legacy Python that doesn't verify HTTPS certificates by default
-    pass
-else:
-    # Handle target environment that doesn't support HTTPS verification
-    ssl._create_default_https_context = _create_unverified_https_context
-
-
-class DoNotVerifySSLSession(requests.sessions.Session):
-    def __init__(self):
-        super().__init__()
-        self.verify = False
-
-    def get(self, url, **kwargs):
-        kwargs.setdefault("verify", False)
-        return super().get(url, **kwargs)
 
 
 class PythonCredentialsTestCase(unittest.TestCase):
@@ -43,16 +20,13 @@ class PythonCredentialsTestCase(unittest.TestCase):
         ).exec
 
     def test_passing_credentials_via_python_works(self):
-        with patch("requests.sessions.Session") as session:
-            session.return_value = DoNotVerifySSLSession()
+        result = self.rpc.User.filter()[0]
 
-            result = self.rpc.User.filter()[0]
+        # this is from config file
+        self.assertNotEqual(result["username"], "kiwitcms-bot")
 
-            # this is from config file
-            self.assertNotEqual(result["username"], "kiwitcms-bot")
-
-            # this is specified in setUpClass() above
-            self.assertEqual(result["username"], "kiwitcms-developer")
+        # this is specified in setUpClass() above
+        self.assertEqual(result["username"], "kiwitcms-developer")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
that should allow Python to verify the HTTPS certificate on the other side of the connection and not complain about it!