### PR TITLE
Sanitize sys.version output

### DIFF
--- a/tcms_api/xmlrpc.py
+++ b/tcms_api/xmlrpc.py
@@ -19,6 +19,7 @@ from tcms_api.version import __version__
 
 
 VERBOSE = 0
+_PYTHON_VERSION = sys.version.replace("\n", "")
 
 
 class TCMSProxy(ServerProxy):
@@ -34,7 +35,7 @@ class CookieTransport(Transport):
     """A subclass of xmlrpc.client.Transport that supports cookies."""
 
     scheme = "http"
-    user_agent = f"tcms-api/{__version__}/Python {sys.version}"
+    user_agent = f"tcms-api/{__version__}/Python {_PYTHON_VERSION}"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Apparently some versions of Python on some platforms add a new-line character inside the version string which breaks HTTP headers:

   File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/http/client.py", line 1263, in putheader
    raise ValueError('Invalid header value %r' % (values[i],))
ValueError: Invalid header value b'tcms-api/12.8.2/Python 3.9.18 (main, Aug 28 2023, 08:38:32) \n[GCC 11.4.0]'