### PR TITLE
Respec configuration as arguments to the TCMS() class

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -91,6 +91,7 @@ jobs:
         _EOF_
 
         make verify-integration
+        make verify-credentials-via-python
 
     - name: Verify tcms-api can communicate over Kerberos
       if: matrix.os == 'ubuntu-latest' && matrix.gssapi == 'with'

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ run-services:
 verify-integration:
 	PYTHONPATH=. python -m coverage run --source tcms_api ./tests/krb5/integration_test.py
 
+.PHONY: verify-credentials-via-python
+verify-credentials-via-python:
+	PYTHONPATH=. python -m coverage run --source tcms_api ./tests/krb5/python_credentials_test.py
+
 .PHONY: verify-curl-with-kerberos
 verify-curl-with-kerberos:
 	# make sure curl supports Negotiate authentication

--- a/tcms_api/__init__.py
+++ b/tcms_api/__init__.py
@@ -120,7 +120,8 @@ class _ConnectionProxy:
         self.__connection = None
         self.__config = config
 
-    def server_url(self, config):
+    @staticmethod
+    def server_url(config):
         """
         Returns the server URL and performs various sanity checks!
         """

--- a/tests/krb5/kiwitcms_kerberos/db_init.py
+++ b/tests/krb5/kiwitcms_kerberos/db_init.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import User
+from django.contrib.auth.models import Permission
 
 from tcms.management.models import Classification
 from tcms.utils.permissions import initiate_user_with_default_setups
@@ -16,3 +17,17 @@ initiate_user_with_default_setups(bot)
 
 # this is used inside integration test
 Classification.objects.create(name="test-products")
+
+# account only to verify credentials passed
+# via Python source code, not config file
+developer = User.objects.create(
+    username="kiwitcms-developer",
+    email="developler@example.com",
+    is_active=True,
+)
+developer.set_password("hack-me")
+developer.save()
+initiate_user_with_default_setups(developer)
+developer.user_permissions.add(
+    Permission.objects.get(content_type__app_label="auth", codename="view_user")
+)

--- a/tests/krb5/python_credentials_test.py
+++ b/tests/krb5/python_credentials_test.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+#
+# Copyright (c) 2024 Kiwi TCMS project. All rights reserved.
+# Author: Alexander Todorov <info@kiwitcms.org>
+#
+
+import ssl
+import unittest
+from unittest.mock import patch
+
+import requests
+from tcms_api import TCMS
+
+
+try:
+    _create_unverified_https_context = ssl._create_unverified_context
+except AttributeError:
+    # Legacy Python that doesn't verify HTTPS certificates by default
+    pass
+else:
+    # Handle target environment that doesn't support HTTPS verification
+    ssl._create_default_https_context = _create_unverified_https_context
+
+
+class DoNotVerifySSLSession(requests.sessions.Session):
+    def __init__(self):
+        super().__init__()
+        self.verify = False
+
+    def get(self, url, **kwargs):
+        kwargs.setdefault("verify", False)
+        return super().get(url, **kwargs)
+
+
+class PythonCredentialsTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rpc = TCMS(
+            url="https://web.kiwitcms.org:8443/json-rpc/",
+            username="kiwitcms-developer",
+            password="hack-me",
+        ).exec
+
+    def test_passing_credentials_via_python_works(self):
+        with patch("requests.sessions.Session") as session:
+            session.return_value = DoNotVerifySSLSession()
+
+            result = self.rpc.User.filter()[0]
+
+            # this is from config file
+            self.assertNotEqual(result["username"], "kiwitcms-bot")
+
+            # this is specified in setUpClass() above
+            self.assertEqual(result["username"], "kiwitcms-developer")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
example:

TCMS("https://kiwitcms.example.com/xml-rpc/", "api-bot", "keep-me-secret")

this should give more flexibility to developers and eliminate reading from the filesystem when dealing entirely with Python.