### PR TITLE
Allow unverified SSL and additional HTTP headers

### DIFF
--- a/tcms_api/__init__.py
+++ b/tcms_api/__init__.py
@@ -119,10 +119,12 @@ from tcms_api.xmlrpc import TCMSXmlrpc, TCMSKerbXmlrpc
 
 
 class _ConnectionProxy:
-    def __init__(self, config):
+    def __init__(self, config, allow_unverified_ssl: bool = False, extra_headers: list[tuple[str, str]] = []):
         self.__connected_since = datetime(2024, 1, 1, 0, 0)
         self.__connection = None
         self.__config = config
+        self.__allow_unverified_ssl = allow_unverified_ssl
+        self.__extra_headers = extra_headers
 
     @staticmethod
     def server_url(config):
@@ -169,6 +171,8 @@ class _ConnectionProxy:
                     config["tcms"]["username"],
                     config["tcms"]["password"],
                     server_url,
+                    allow_unverified_ssl=self.__allow_unverified_ssl,
+                    extra_headers=self.__extra_headers,
                 )
             except KeyError as err:
                 raise RuntimeError(f"username/password required in '{path}'") from err
@@ -206,7 +210,7 @@ class TCMS:  # pylint: disable=too-few-public-methods
     parses user configuration using a utilities class!
     """
 
-    def __init__(self, url=None, username=None, password=None):
+    def __init__(self, url=None, username=None, password=None, allow_unverified_ssl: bool = False, extra_headers: list[tuple[str, str]] = []):
         self.config = {
             "tcms": {
                 "url": url,
@@ -214,6 +218,9 @@ class TCMS:  # pylint: disable=too-few-public-methods
                 "password": password,
             }
         }
+
+        self.allow_unverified_ssl = allow_unverified_ssl
+        self.extra_headers = extra_headers
 
     @property
     def exec(self):
@@ -230,4 +237,6 @@ class TCMS:  # pylint: disable=too-few-public-methods
             Starting with tcms-api v12.9.1 this property is automatically refreshed
             every 4 minutes to avoid SSL connection timeout errors!
         """
-        return _ConnectionProxy(self.config)
+        return _ConnectionProxy(config=self.config,
+                                allow_unverified_ssl=self.allow_unverified_ssl,
+                                extra_headers=self.extra_headers)

--- a/tcms_api/xmlrpc.py
+++ b/tcms_api/xmlrpc.py
@@ -1,6 +1,8 @@
 # pylint: disable=protected-access,too-few-public-methods
 
+import ssl
 import sys
+from typing import Optional
 import urllib.parse
 
 from base64 import b64encode
@@ -114,7 +116,7 @@ class TCMSXmlrpc:
     session_cookie_name = "sessionid"
     transport = None
 
-    def __init__(self, username, password, url):
+    def __init__(self, username, password, url, allow_unverified_ssl: bool = False, extra_headers: list[tuple[str, str]]=[]):
         if self.transport is None:
             if url.startswith("https://"):
                 self.transport = SafeCookieTransport()
@@ -122,6 +124,12 @@ class TCMSXmlrpc:
                 self.transport = CookieTransport()
             else:
                 raise RuntimeError("Unrecognized URL scheme")
+
+        if allow_unverified_ssl:
+            ssl._create_default_https_context = ssl._create_unverified_context
+
+        if len(extra_headers) > 0:
+            self.transport._headers += extra_headers
 
         self.server = TCMSProxy(
             url, transport=self.transport, verbose=VERBOSE, allow_none=1


### PR DESCRIPTION
Hi, thank you for creating this API client and Kiwi TCMS itself.

I've added two new features that I've found useful:
1. Allow unverified SSL connection (example use-case is when running Kiwi locally, if self-signed certificate is not trusted)
2. Allow passing additional headers in HTTP requests. This is useful for cases where you may need to authenticate with a proxy for example (`Proxy-Authorization` header).

The changes should be backwards compatible due to setting default values for these new parameters.

Please let me know if there is anything you'd like to change though before you'd consider merging.